### PR TITLE
Use upgrade routine instead of activation hook

### DIFF
--- a/app/DatabaseSchema.php
+++ b/app/DatabaseSchema.php
@@ -12,22 +12,27 @@ class DatabaseSchema implements \Dxw\Iguana\Registerable
 
     public function register()
     {
-        register_activation_hook(dirname(__DIR__).'/contact-form-7-rate-limiting.php', [$this, 'activationHook']);
+        add_action('admin_init', [$this, 'adminInit']);
     }
 
-    public function activationHook()
+    public function adminInit()
     {
-        require($this->abspath.'/wp-admin/includes/upgrade.php');
-        // Arguments to dbDelta untested
-        // timestamp = 0000-00-00T00:00:00 = 23 bytes
-        // source = 0000:0000:0000:0000:0000:0000:0000:0000/128 = 43 bytes
-        dbDelta("
-        CREATE TABLE {$this->wpdb->prefix}cf7_rate_limiting (
-            id INT NOT NULL AUTO_INCREMENT,
-            timestamp VARCHAR(23),
-            source VARCHAR(43),
-            PRIMARY KEY (id)
-        ) {$this->wpdb->get_charset_collate()};
-        ");
+        $version = (int)get_option('cf7_rate_limiting_version');
+        if ($version < 1) {
+            require($this->abspath.'/wp-admin/includes/upgrade.php');
+            // Arguments to dbDelta untested
+            // timestamp = 0000-00-00T00:00:00 = 23 bytes
+            // source = 0000:0000:0000:0000:0000:0000:0000:0000/128 = 43 bytes
+            dbDelta("
+            CREATE TABLE {$this->wpdb->prefix}cf7_rate_limiting (
+                id INT NOT NULL AUTO_INCREMENT,
+                timestamp VARCHAR(23),
+                source VARCHAR(43),
+                PRIMARY KEY (id)
+            ) {$this->wpdb->get_charset_collate()};
+            ");
+
+            update_option('cf7_rate_limiting_version', 1);
+        }
     }
 }

--- a/app/DatabaseSchema.php
+++ b/app/DatabaseSchema.php
@@ -12,10 +12,10 @@ class DatabaseSchema implements \Dxw\Iguana\Registerable
 
     public function register()
     {
-        add_action('admin_init', [$this, 'adminInit']);
+        add_action('init', [$this, 'init']);
     }
 
-    public function adminInit()
+    public function init()
     {
         $version = (int)get_option('cf7_rate_limiting_version');
         if ($version < 1) {

--- a/spec/database_schema.spec.php
+++ b/spec/database_schema.spec.php
@@ -21,14 +21,14 @@ describe(\Dxw\ContactForm7RateLimiting\DatabaseSchema::class, function () {
     });
 
     describe('->register()', function () {
-        it('registers admin_init hook', function () {
-            \WP_Mock::expectActionAdded('admin_init', [$this->databaseSchema, 'adminInit']);
+        it('registers init hook', function () {
+            \WP_Mock::expectActionAdded('init', [$this->databaseSchema, 'init']);
 
             $this->databaseSchema->register();
         });
     });
 
-    describe('->adminInit()', function () {
+    describe('->init()', function () {
         beforeEach(function () {
             mkdir($this->abspath.'/wp-admin');
             mkdir($this->abspath.'/wp-admin/includes');
@@ -54,7 +54,7 @@ describe(\Dxw\ContactForm7RateLimiting\DatabaseSchema::class, function () {
                     'times' => 1,
                 ]);
 
-                $this->databaseSchema->adminInit();
+                $this->databaseSchema->init();
                 expect($GLOBALS['has been included'])->to->be->true();
             });
         });
@@ -73,7 +73,7 @@ describe(\Dxw\ContactForm7RateLimiting\DatabaseSchema::class, function () {
                     'times' => 0,
                 ]);
 
-                $this->databaseSchema->adminInit();
+                $this->databaseSchema->init();
                 expect($GLOBALS['has been included'])->to->be->false();
             });
         });

--- a/spec/database_schema.spec.php
+++ b/spec/database_schema.spec.php
@@ -21,29 +21,61 @@ describe(\Dxw\ContactForm7RateLimiting\DatabaseSchema::class, function () {
     });
 
     describe('->register()', function () {
-        it('registers activation hook', function () {
-            \WP_Mock::wpFunction('register_activation_hook', [
-                'args' => [dirname(__DIR__).'/contact-form-7-rate-limiting.php', [$this->databaseSchema, 'activationHook']],
-                'times' => 1,
-            ]);
+        it('registers admin_init hook', function () {
+            \WP_Mock::expectActionAdded('admin_init', [$this->databaseSchema, 'adminInit']);
 
             $this->databaseSchema->register();
         });
     });
 
-    describe('->activationHook()', function () {
-        it('includes upgrade.php and calls dbDelta', function () {
+    describe('->adminInit()', function () {
+        beforeEach(function () {
             mkdir($this->abspath.'/wp-admin');
             mkdir($this->abspath.'/wp-admin/includes');
             file_put_contents($this->abspath.'/wp-admin/includes/upgrade.php', '<?php $GLOBALS["has been included"] = true;');
             $GLOBALS['has been included'] = false;
+        });
 
-            \WP_Mock::wpFunction('dbDelta', [
-                'times' => 1,
-            ]);
+        context('when version is unset', function () {
+            beforeEach(function () {
+                \WP_Mock::wpFunction('get_option', [
+                    'args' => ['cf7_rate_limiting_version'],
+                    'return' => false,
+                ]);
+            });
 
-            $this->databaseSchema->activationHook();
-            expect($GLOBALS['has been included'])->to->be->true();
+            it('includes upgrade.php, calls dbDelta, and sets version to 1', function () {
+                \WP_Mock::wpFunction('dbDelta', [
+                    'times' => 1,
+                ]);
+
+                \WP_Mock::wpFunction('update_option', [
+                    'args' => ['cf7_rate_limiting_version', 1],
+                    'times' => 1,
+                ]);
+
+                $this->databaseSchema->adminInit();
+                expect($GLOBALS['has been included'])->to->be->true();
+            });
+        });
+
+        context('when version is 1', function () {
+            beforeEach(function () {
+                \WP_Mock::wpFunction('get_option', [
+                    'args' => ['cf7_rate_limiting_version'],
+                    'return' => 1,
+                ]);
+            });
+
+            it('does nothing', function () {
+                \WP_Mock::wpFunction('update_option', [
+                    'args' => ['cf7_rate_limiting_version', 1],
+                    'times' => 0,
+                ]);
+
+                $this->databaseSchema->adminInit();
+                expect($GLOBALS['has been included'])->to->be->false();
+            });
         });
     });
 });


### PR DESCRIPTION
Activation hooks do not work with multisite, and instead of fixing that
issue, @nacin recommends using an "upgrade routine".

Resolves: https://dxw.zendesk.com/agent/tickets/7128